### PR TITLE
Various compatibility changes

### DIFF
--- a/src/Number/random.php
+++ b/src/Number/random.php
@@ -74,5 +74,5 @@ function random($lower = null, $upper = null, $floating = null)
         return $lower + \abs($upper - $lower) * \mt_rand(0, $randMax) / $randMax;
     }
 
-    return \rand((int) $lower, (int) $upper);
+    return random_int((int) $lower, (int) $upper);
 }

--- a/src/Number/random.php
+++ b/src/Number/random.php
@@ -74,5 +74,5 @@ function random($lower = null, $upper = null, $floating = null)
         return $lower + \abs($upper - $lower) * \mt_rand(0, $randMax) / $randMax;
     }
 
-    return random_int((int) $lower, (int) $upper);
+    return \random_int((int) $lower, (int) $upper);
 }

--- a/src/String/template.php
+++ b/src/String/template.php
@@ -120,17 +120,17 @@ function template(string $string, array $options = []): callable
 
         if ($escapeValue) {
             $escapeValue = \trim($escapeValue);
-            $source .= "<?=__e(\$${escapeValue});?>";
+            $source .= "<?=__e(\${$escapeValue});?>";
         }
 
         if ($evaluateValue) {
-            $source .= "<?php \n${evaluateValue} ?>";
+            $source .= "<?php \n{$evaluateValue} ?>";
         }
 
         if ($interpolateValue) {
             $interpolateValue = \trim($interpolateValue ?? $esTemplateValue);
             $interpolateValue = \preg_replace('#^([\p{L}\p{N}_]+)$#u', '$$1', $interpolateValue);
-            $source .= "<?=${interpolateValue};?>";
+            $source .= "<?={$interpolateValue};?>";
         }
 
         return $source;

--- a/src/String/truncate.php
+++ b/src/String/truncate.php
@@ -101,7 +101,7 @@ function truncate($string, array $options = [])
                 $newEnd = \end($match[0])[1];
             }
 
-            $result = \substr($result, 0, null === $newEnd ? $end : $newEnd);
+            $result = \substr($result, 0, $newEnd ?? $end);
         }
     } elseif (\strpos($string, $separator) !== $end) {
         $index = \strrpos($result, $separator);

--- a/src/internal/baseMatches.php
+++ b/src/internal/baseMatches.php
@@ -21,7 +21,7 @@ function baseMatches($source): callable
             return true;
         }
 
-        if (\is_array($source) || $source instanceof \Traversable) {
+        if (\is_iterable($source)) {
             foreach ($source as $k => $v) {
                 if (!isEqual(property($k)($value, $index, $collection), $v)) {
                     return false;

--- a/src/internal/castSlice.php
+++ b/src/internal/castSlice.php
@@ -25,7 +25,7 @@ namespace _\internal;
 function castSlice(array $array, int $start, ?int $end = null): array
 {
     $length = \count($array);
-    $end = null === $end ? $length : $end;
+    $end = $end ?? $length;
 
     return (!$start && $end >= $length) ? $array : \array_slice($array, $start, $end);
 }


### PR DESCRIPTION
- The `rand()` function, which generates a pseudo-random number, is replaced with the `random_int()` function in the `random.php` file. The `random_int()` function is a cryptographically secure function introduced in PHP7 that generates a random integer.
- In `truncate.php` and `castSlice.php`, the null coalescing operator (`??`) is used. This operator checks if the variable on its left-hand side is set and not null, and if so, it returns its own value; otherwise, it returns the value of the variable on the right-hand side.
- The function `baseMatches.php` now uses `is_iterable()`, a function introduced in PHP 7.1, to check if a variable is an array or a traversable object instead of the combination of `is_array()` and `instanceof Traversable`.
- In template.php, string interpolation is updated to comply with the latest standards, due to a PHP deprecation warning against the use of `${var}` syntax. Instead, `{$var}` syntax is used for variable parsing within a string.