### PR TITLE
Add 6.x to property access because it blocks install in updated projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "sebastian/comparator": "^1.2 | ^2.0 | ^2.1 | ^3.0 | ^4.0",
-        "symfony/property-access": "^2.7 | ^3.0 | ^4.0 | ^5.0"
+        "symfony/property-access": "^2.7 | ^3.0 | ^4.0 | ^5.0 | ^6.0"
     },
     "require-dev": {
         "phpdocumentor/reflection-docblock": "*",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^7.2 || ^8.0",
-        "sebastian/comparator": "^1.2 | ^2.0 | ^2.1 | ^3.0 | ^4.0",
+        "sebastian/comparator": "^1.2 | ^2.0 | ^2.1 | ^3.0 | ^4.0 | ^5.0",
         "symfony/property-access": "^2.7 | ^3.0 | ^4.0 | ^5.0 | ^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
At work, we are moving to Symfony 6.x and your reference to property-access 5.x is blocking the upgrade. Can you please accept this ASAP or we'll have to forfeit using your lib.